### PR TITLE
[FIX][RR] corregimos xpath en vista account.move 

### DIFF
--- a/sale_order_type/__manifest__.py
+++ b/sale_order_type/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Sale Order Type",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "category": "Sales Management",
     "author": "Grupo Vermon,"
     "AvanzOSC,"

--- a/sale_order_type/views/account_move_views.xml
+++ b/sale_order_type/views/account_move_views.xml
@@ -10,7 +10,8 @@
                     attrs="{'invisible': [('move_type', 'not in', ['out_invoice', 'out_refund'])]}"
                 />
             </label>
-            <xpath expr="//notebook//tree//field[@name='sequence']" position="before">
+            <!-- TRESCLOUD: arreglamos xpath siendo más específicos, evitamos que se seleccione otro sequence (l10n_ec_custom_line_ids) -->
+            <xpath expr="//notebook//page[@id='invoice_tab']//tree//field[@name='sequence']" position="before">
                 <field name="account_id" invisible="1" />
             </xpath>
         </field>


### PR DESCRIPTION
- El xpath anterior selecciona el sequence de nuestro campo l10n_ec_custom_line_ids lo cual produce un error al querer instalar/actualizar que indica que no encuentra el account_id