### PR TITLE
[FIX] sale_order_type: Error in xpath of accounting entries view

### DIFF
--- a/sale_order_type/views/account_move_views.xml
+++ b/sale_order_type/views/account_move_views.xml
@@ -11,7 +11,7 @@
                     readonly="state != 'draft'"
                 />
             </label>
-            <xpath expr="//notebook//list//field[@name='sequence']" position="before">
+            <xpath expr="//notebook//page[@id='invoice_tab']//list//field[@name='sequence']" position="before">
                 <field name="account_id" column_invisible="True" />
             </xpath>
         </field>


### PR DESCRIPTION
- In our custom lines module, we add a page to the form tabs. This causes it to not find the inheritance of this view. We fix the inheritance so that it is more specific to search for invoice lines.