### PR TITLE
[IMP] tier_validation: Instalación de módulos de validaciones de niveles de la OCA

### DIFF
--- a/sale_tier_validation/__manifest__.py
+++ b/sale_tier_validation/__manifest__.py
@@ -11,6 +11,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
+    "auto_install": True, # TRESCLOUD: Util para instalación automática desde el autoinstaller
     "depends": ["sale", "base_tier_validation"],
     "data": [
         "data/mail_data.xml",


### PR DESCRIPTION
- Se añade sale_tier_validation para instalar el módulo sale_tier_validation_rules que centraliza las validaciones de niveles de la OCA.

Tarea: #9924